### PR TITLE
Including reconnect.py for unmanaged sims and updating README with in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,15 +248,15 @@ docker pull azhvacacr.azurecr.io/hvac:1.0
 docker run -it azhvacacr.azurecr.io/hvac:1.0 bash
 ```
 
-##  Reasons Your Unmanaged Sims May Unregister
+## Reasons Your Unmanaged Sims May Become Unregistered
 
-Simulators may unregister with the Bonsai platform for the following reasons:
+Simulators may unregister from the Bonsai platform for any of the following reasons:
 
-- Software update to Bonsai platform unregisters all sims
+- Software update to Bonsai platform
 - WaitForState timeout
 - WaitForAction timeout
 
-When using managed simulators, we simply re-register and connect sims for a software update. When using unmanaged simulators like with the `bonsai-batch` tool, we will have to do it ourselves. Run `reconnect.py` with the following flags to repeatedly look for sims with Unset purpose and connect those specific session-id's.
+When using managed simulators, the platform will automatically re-register and connect sims when they unregister. When using unmanaged simulators, such as with the `bonsai-batch` scripts, the user is responsible for registering the simulators again. To aid this effort, the [`reconnect.py`](./reconnect.py) with the following flags to repeatedly look for sims with an `Unset` purpose and connect those specific session-id's back with your brain.
 
 ```bash
 python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brain-version 1 --concept-name SmartHouse --interval 1

--- a/README.md
+++ b/README.md
@@ -248,6 +248,20 @@ docker pull azhvacacr.azurecr.io/hvac:1.0
 docker run -it azhvacacr.azurecr.io/hvac:1.0 bash
 ```
 
+##  Reasons Your Unmanaged Sims May Unregister
+
+Simulators may unregister with the Bonsai platform for the following reasons:
+
+- Software update to Bonsai platform unregisters all sims
+- WaitForState timeout
+- WaitForAction timeout
+
+When using managed simulators, we simply re-register and connect sims for a software update. When using unmanaged simulators like with the `bonsai-batch` tool, we will have to do it ourselves. Run `reconnect.py` with the following flags to repeatedly look for sims with Unset purpose and connect those specific session-id's.
+
+```bash
+python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brain-version 1 --concept-name SmartHouse --interval 1
+```
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/reconnect.py
+++ b/reconnect.py
@@ -8,113 +8,146 @@ __author__ = "Brice Chung"
 __version__ = "0.0.2"
 
 import subprocess, argparse, datetime, time
-import os
 import json
+
 
 def parse_sim_status():
     """ Function to parse bonsai simulator unmanaged list
     """
     unset_sims = []
-    
-    with open('sim_list.json') as f:
+
+    with open("sim_list.json") as f:
         sim_list = json.load(f)
-    
-    for instance in sim_list['value']:
-        if instance['action'] == 'Unset':
-            unset_sims.append(instance['sessionId'])
+
+    for instance in sim_list["value"]:
+        if instance["action"] == "Unset":
+            unset_sims.append(instance["sessionId"])
         else:
             pass
     return unset_sims
 
-def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concept_name: str, action: str = 'Train'):
+
+def connect_sim(
+    simulator_name: str,
+    brain_name: str,
+    brain_version: str,
+    concept_name: str,
+    action: str = "Train",
+):
     """ Reconnect simulator to brain
     """
-    timeout_value = 15*60 # in s
-    retry_wait = 1*60 # in s
-    max_retries = 10 # number of retries if timeout or errors
+    timeout_value = 15 * 60  # in s
+    retry_wait = 1 * 60  # in s
+    max_retries = 10  # number of retries if timeout or errors
     retry_count = 0
-    list_cmd = 'bonsai simulator unmanaged list --simulator-name {} -o json'.format(simulator_name)
-    
+    list_cmd = "bonsai simulator unmanaged list --simulator-name {} -o json".format(
+        simulator_name
+    )
+
     while retry_count < max_retries:
         try:
-            with open('sim_list.json', 'w') as outfile:
-                subprocess.run(list_cmd.split(), timeout=timeout_value, check=True, stdout=outfile)
+            with open("sim_list.json", "w") as outfile:
+                subprocess.run(
+                    list_cmd.split(), timeout=timeout_value, check=True, stdout=outfile
+                )
             time.sleep(1)
             try:
                 unset_sims = parse_sim_status()
             except:
-                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
+                print(
+                    "ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims or increase command timeout in reconnect.py if issue persists.".format(
+                        retry_count
+                    )
+                )
                 time.sleep(retry_wait)
                 continue
             for sessid in unset_sims:
-                connect_cmd = 'bonsai simulator unmanaged connect \
+                connect_cmd = "bonsai simulator unmanaged connect \
                     --session-id {} \
                     --brain-name {} \
                     --brain-version {} \
                     --concept-name {} \
-                    --action {}'.format(sessid, brain_name, brain_version, concept_name, action)
+                    --action {}".format(
+                    sessid, brain_name, brain_version, concept_name, action
+                )
                 subprocess.run(connect_cmd.split(), timeout=timeout_value, check=True)
         except subprocess.TimeoutExpired:
-                print('{}: command timeout, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
-                time.sleep(retry_wait)
+            print(
+                "{}: command timeout, will retry in {} min, retry attempt {} out of {}".format(
+                    datetime.datetime.now(), retry_wait / 60, retry_count, max_retries
+                )
+            )
+            time.sleep(retry_wait)
         except subprocess.SubprocessError:
-                print('{}: command error, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
-                time.sleep(retry_wait)
-        else: 
+            print(
+                "{}: command error, will retry in {} min, retry attempt {} out of {}".format(
+                    datetime.datetime.now(), retry_wait / 60, retry_count, max_retries
+                )
+            )
+            time.sleep(retry_wait)
+        else:
             break
         finally:
             retry_count += 1
 
+
 if __name__ == "__main__":
-    
+
     parser = argparse.ArgumentParser(description="reconnect sim")
     parser.add_argument(
-            "--simulator-name",
-            type=str,
-            default=None,
-            help="simulator name of sims to connect to brain",
-        )
+        "--simulator-name",
+        type=str,
+        default=None,
+        help="simulator name of sims to connect to brain",
+    )
     parser.add_argument(
-            "-b",
-            "--brain-name",
-            type=str,
-            default=None,
-            help="brain name for sim to connect to",
-        )
+        "-b",
+        "--brain-name",
+        type=str,
+        default=None,
+        help="brain name for sim to connect to",
+    )
 
     parser.add_argument(
-            "--brain-version",
-            type=str,
-            default=None,
-            help="brain version for sim to connect to",
-        )
+        "--brain-version",
+        type=str,
+        default=None,
+        help="brain version for sim to connect to",
+    )
 
     parser.add_argument(
-            "-c",
-            "--concept-name",
-            type=str,
-            default=None,
-            help="concept name for sim to connect to",
-        )
-    
+        "-c",
+        "--concept-name",
+        type=str,
+        default=None,
+        help="concept name for sim to connect to",
+    )
+
     parser.add_argument(
-            "-a",
-            "--action",
-            type=str,
-            default='Train',
-            help="action value can be Train or Assess",
-        )
-    
+        "-a",
+        "--action",
+        type=str,
+        default="Train",
+        help="action value can be Train or Assess",
+    )
+
     parser.add_argument(
-            "--interval",
-            type=int,
-            default=None,
-            help="interval to periodically run reconnect in minutes",
-        )
+        "--interval",
+        type=int,
+        default=None,
+        help="interval to periodically run reconnect in minutes",
+    )
 
     args = parser.parse_args()
-    if args.simulator_name is None or args.brain_name is None or args.brain_version is None or args.concept_name is None:
-        parser.error("reconnect requires --simulator-name, --brain-name, --brain-version and --concept-name")
+    if (
+        args.simulator_name is None
+        or args.brain_name is None
+        or args.brain_version is None
+        or args.concept_name is None
+    ):
+        parser.error(
+            "reconnect requires --simulator-name, --brain-name, --brain-version and --concept-name"
+        )
     elif args.interval is None:
         parser.error("needs --interval in minutes")
 
@@ -124,7 +157,11 @@ if __name__ == "__main__":
             brain_name=args.brain_name,
             brain_version=args.brain_version,
             concept_name=args.concept_name,
-            action=args.action
+            action=args.action,
         )
-        print('{}: reconnect will execute in {} min'.format(datetime.datetime.now(),args.interval))
-        time.sleep(args.interval*60)
+        print(
+            "{}: reconnect will execute in {} min".format(
+                datetime.datetime.now(), args.interval
+            )
+        )
+        time.sleep(args.interval * 60)

--- a/reconnect.py
+++ b/reconnect.py
@@ -1,0 +1,130 @@
+""" 
+Periodically reconnect simulators to a brain
+example usage with a reconnection executed every minute: 
+python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brain-version 1 --concept-name SmartHouse --interval 1
+"""
+
+__author__ = "Brice Chung"
+__version__ = "0.0.2"
+
+import subprocess, argparse, datetime, time
+import os
+import json
+
+def parse_sim_status():
+    """ Function to parse bonsai simulator unmanaged list
+    """
+    unset_sims = []
+    
+    with open('sim_list.json') as f:
+        sim_list = json.load(f)
+    
+    for instance in sim_list['value']:
+        if instance['action'] == 'Unset':
+            unset_sims.append(instance['sessionId'])
+        else:
+            pass
+    return unset_sims
+
+def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concept_name: str, action: str = 'Train'):
+    """ Reconnect simulator to brain
+    """
+    timeout_value = 15*60 # in s
+    retry_wait = 1*60 # in s
+    max_retries = 10 # number of retries if timeout or errors
+    retry_count = 0
+    list_cmd = 'bonsai simulator unmanaged list --simulator-name {} -o json'.format(simulator_name)
+    
+    while retry_count < max_retries:
+        try:
+            with open('sim_list.json', 'w') as outfile:
+                subprocess.run(list_cmd.split(), timeout=timeout_value, check=True, stdout=outfile)
+            time.sleep(1)
+            try:
+                unset_sims = parse_sim_status()
+            except:
+                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
+                time.sleep(retry_wait)
+                continue
+            for sessid in unset_sims:
+                connect_cmd = 'bonsai simulator unmanaged connect \
+                    --session-id {} \
+                    --brain-name {} \
+                    --brain-version {} \
+                    --concept-name {} \
+                    --action {}'.format(sessid, brain_name, brain_version, concept_name, action)
+                subprocess.run(connect_cmd.split(), timeout=timeout_value, check=True)
+        except subprocess.TimeoutExpired:
+                print('{}: command timeout, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
+                time.sleep(retry_wait)
+        except subprocess.SubprocessError:
+                print('{}: command error, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
+                time.sleep(retry_wait)
+        else: 
+            break
+        finally:
+            retry_count += 1
+
+if __name__ == "__main__":
+    
+    parser = argparse.ArgumentParser(description="reconnect sim")
+    parser.add_argument(
+            "--simulator-name",
+            type=str,
+            default=None,
+            help="simulator name of sims to connect to brain",
+        )
+    parser.add_argument(
+            "-b",
+            "--brain-name",
+            type=str,
+            default=None,
+            help="brain name for sim to connect to",
+        )
+
+    parser.add_argument(
+            "--brain-version",
+            type=str,
+            default=None,
+            help="brain version for sim to connect to",
+        )
+
+    parser.add_argument(
+            "-c",
+            "--concept-name",
+            type=str,
+            default=None,
+            help="concept name for sim to connect to",
+        )
+    
+    parser.add_argument(
+            "-a",
+            "--action",
+            type=str,
+            default='Train',
+            help="action value can be Train or Assess",
+        )
+    
+    parser.add_argument(
+            "--interval",
+            type=int,
+            default=None,
+            help="interval to periodically run reconnect in minutes",
+        )
+
+    args = parser.parse_args()
+    if args.simulator_name is None or args.brain_name is None or args.brain_version is None or args.concept_name is None:
+        parser.error("reconnect requires --simulator-name, --brain-name, --brain-version and --concept-name")
+    elif args.interval is None:
+        parser.error("needs --interval in minutes")
+
+    while True:
+        connect_sim(
+            simulator_name=args.simulator_name,
+            brain_name=args.brain_name,
+            brain_version=args.brain_version,
+            concept_name=args.concept_name,
+            action=args.action
+        )
+        print('{}: reconnect will execute in {} min'.format(datetime.datetime.now(),args.interval))
+        time.sleep(args.interval*60)


### PR DESCRIPTION
Simulators may unregister with the Bonsai platform for the following reasons:

- Software update to Bonsai platform unregisters all sims
- WaitForState timeout
- WaitForAction timeout

When using managed simulators, we simply re-register and connect sims for a software update. When using unmanaged simulators like with the `bonsai-batch` tool, we will have to do it ourselves. Run `reconnect.py` with the following flags to repeatedly look for sims with Unset purpose and connect those specific session-id's.

```bash
python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brain-version 1 --concept-name SmartHouse --interval 1
```