### PR TITLE
Adjusted reconnect.py for ignoring zombie session id's during deploym…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,12 +8,12 @@ dependencies:
   - scipy=1.3.0
   - seaborn=0.9.0
   - pip:
-      - azure-batch==9.0.0
-      - azure-cli==2.12.1
+      - azure-batch==10.0.0
+      - azure-cli==2.23.0
       - beautifulsoup4==4.9.1
       - bitstring==3.1.7
       - blobxfer==1.9.2
-      - bonsai-cli==1.0.5
+      - bonsai-cli==1.0.8
       - cufflinks==0.16
       - fire==0.2.1
       - microsoft-bonsai-api==0.1.2

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
       - beautifulsoup4==4.9.1
       - bitstring==3.1.7
       - blobxfer==1.9.2
-      - bonsai-cli==1.0.4
+      - bonsai-cli==1.0.5
       - cufflinks==0.16
       - fire==0.2.1
       - microsoft-bonsai-api==0.1.2

--- a/reconnect.py
+++ b/reconnect.py
@@ -59,9 +59,7 @@ def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concep
             try:
                 unset_sims = parse_sim_status(to_reverse)
             except:
-                logger.warning(
-                    f'ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.'.format(retry_count)
-                )
+                logger.warning(f'No sims are available with your criteria from bonsai simulator list. Retrying {retry_count}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.')
                 continue
             for sessid in unset_sims:
                 if sessid not in blocked_list:
@@ -75,21 +73,21 @@ def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concep
                 else:
                     pass
         except subprocess.TimeoutExpired:
-            print('{}: command timeout, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
+            logger.info(f'{datetime.datetime.now()}: command timeout, will retry in {retry_wait/60} min, retry attempt {retry_count} out of {max_retries}')
             time.sleep(retry_wait)
         except subprocess.SubprocessError:
             try: 
-                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-                print("We may be going through a deployment and session id: {} has become invalidated, ignoring...".format(sessid))
+                logger.info(f'~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                logger.info(f"We may be going through a deployment and session id: {sessid} has become invalidated, ignoring...")
                 blocked_list.append(sessid)
-                print('blocked list: {}'.format(blocked_list))
-                print('{}: command error, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
-                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                logger.info(f'blocked list: {blocked_list}')
+                logger.info(f'{datetime.datetime.now()}: command error, will retry in {retry_wait/60} min, retry attempt {retry_count} out of {max_retries}')
+                logger.info(f'~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
                 time.sleep(retry_wait)
             except:
-                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
-                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                logger.info(f'~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                logger.info(f'ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {retry_count}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.')
+                logger.info(f'~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
                 time.sleep(retry_wait)
         else: 
             break
@@ -164,5 +162,5 @@ if __name__ == "__main__":
             action=args.action,
             to_reverse=to_reverse,
         )
-        print('{}: reconnect will execute in {} min'.format(datetime.datetime.now(),args.interval))
+        logger.info(f'{datetime.datetime.now()}: reconnect will execute in {args.interval} min')
         time.sleep(args.interval*60)

--- a/reconnect.py
+++ b/reconnect.py
@@ -86,7 +86,7 @@ def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concep
                 time.sleep(retry_wait)
             except:
                 logger.info(f'~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-                logger.info(f'ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {retry_count}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.')
+                logger.info(f'No sims are available with your criteria from bonsai simulator list. Retrying {retry_count}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.')
                 logger.info(f'~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
                 time.sleep(retry_wait)
         else: 

--- a/reconnect.py
+++ b/reconnect.py
@@ -1,167 +1,151 @@
 """ 
 Periodically reconnect simulators to a brain
 example usage with a reconnection executed every minute: 
-python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brain-version 1 --concept-name SmartHouse --interval 1
+python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brain-version 1 --concept-name SmartHouse --interval 15
 """
 
 __author__ = "Brice Chung"
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 import subprocess, argparse, datetime, time
+import os
 import json
 
-
-def parse_sim_status():
+def parse_sim_status(to_reverse=False):
     """ Function to parse bonsai simulator unmanaged list
     """
     unset_sims = []
-
-    with open("sim_list.json") as f:
+    
+    with open('sim_list.json') as f:
         sim_list = json.load(f)
-
-    for instance in sim_list["value"]:
-        if instance["action"] == "Unset":
-            unset_sims.append(instance["sessionId"])
+    
+    for instance in sim_list['value']:
+        if instance['action'] == 'Unset':
+            unset_sims.append(instance['sessionId'])
         else:
             pass
-    return unset_sims
+    
+    # If lingering sims are clustered in beginning of query list, go to the back and start connecting sims
+    if to_reverse:
+        return reversed(unset_sims)
+    else:
+        return unset_sims
 
-
-def connect_sim(
-    simulator_name: str,
-    brain_name: str,
-    brain_version: str,
-    concept_name: str,
-    action: str = "Train",
-):
+def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concept_name: str, action: str = 'Train', to_reverse=False):
     """ Reconnect simulator to brain
     """
-    timeout_value = 15 * 60  # in s
-    retry_wait = 1 * 60  # in s
-    max_retries = 10  # number of retries if timeout or errors
+    timeout_value = 5*60 # in s
+    retry_wait = 0.1 # in s
+    max_retries = 15 # number of retries if timeout or errors
     retry_count = 0
-    list_cmd = "bonsai simulator unmanaged list --simulator-name {} -o json".format(
-        simulator_name
-    )
-
+    list_cmd = 'bonsai simulator unmanaged list --simulator-name {} -o json'.format(simulator_name)
+    blocked_list = []
+    
     while retry_count < max_retries:
         try:
-            with open("sim_list.json", "w") as outfile:
-                subprocess.run(
-                    list_cmd.split(), timeout=timeout_value, check=True, stdout=outfile
-                )
+            with open('sim_list.json', 'w') as outfile:
+                subprocess.run(list_cmd.split(), timeout=timeout_value, check=True, stdout=outfile)
             time.sleep(1)
             try:
-                unset_sims = parse_sim_status()
+                unset_sims = parse_sim_status(to_reverse)
             except:
-                print(
-                    "ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims or increase command timeout in reconnect.py if issue persists.".format(
-                        retry_count
-                    )
-                )
+                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
                 time.sleep(retry_wait)
                 continue
             for sessid in unset_sims:
-                connect_cmd = "bonsai simulator unmanaged connect \
-                    --session-id {} \
-                    --brain-name {} \
-                    --brain-version {} \
-                    --concept-name {} \
-                    --action {}".format(
-                    sessid, brain_name, brain_version, concept_name, action
-                )
-                subprocess.run(connect_cmd.split(), timeout=timeout_value, check=True)
+                if sessid not in blocked_list:
+                    connect_cmd = 'bonsai simulator unmanaged connect \
+                        --session-id {} \
+                        --brain-name {} \
+                        --brain-version {} \
+                        --concept-name {} \
+                        --action {}'.format(sessid, brain_name, brain_version, concept_name, action)
+                    subprocess.run(connect_cmd.split(), timeout=timeout_value, check=True)
+                else:
+                    pass
         except subprocess.TimeoutExpired:
-            print(
-                "{}: command timeout, will retry in {} min, retry attempt {} out of {}".format(
-                    datetime.datetime.now(), retry_wait / 60, retry_count, max_retries
-                )
-            )
+            print('{}: command timeout, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
             time.sleep(retry_wait)
         except subprocess.SubprocessError:
-            print(
-                "{}: command error, will retry in {} min, retry attempt {} out of {}".format(
-                    datetime.datetime.now(), retry_wait / 60, retry_count, max_retries
-                )
-            )
+            print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+            print("We may be going through a deployment and session id: {} has become invalidated, ignoring...".format(sessid))
+            blocked_list.append(sessid)
+            print('blocked list: {}'.format(blocked_list))
+            print('{}: command error, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
+            print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
             time.sleep(retry_wait)
-        else:
+        else: 
             break
         finally:
             retry_count += 1
 
-
 if __name__ == "__main__":
-
+    
     parser = argparse.ArgumentParser(description="reconnect sim")
     parser.add_argument(
-        "--simulator-name",
-        type=str,
-        default=None,
-        help="simulator name of sims to connect to brain",
-    )
+            "--simulator-name",
+            type=str,
+            default=None,
+            help="simulator name of sims to connect to brain",
+        )
     parser.add_argument(
-        "-b",
-        "--brain-name",
-        type=str,
-        default=None,
-        help="brain name for sim to connect to",
-    )
+            "-b",
+            "--brain-name",
+            type=str,
+            default=None,
+            help="brain name for sim to connect to",
+        )
 
     parser.add_argument(
-        "--brain-version",
-        type=str,
-        default=None,
-        help="brain version for sim to connect to",
-    )
+            "--brain-version",
+            type=str,
+            default=None,
+            help="brain version for sim to connect to",
+        )
 
     parser.add_argument(
-        "-c",
-        "--concept-name",
-        type=str,
-        default=None,
-        help="concept name for sim to connect to",
-    )
-
+            "-c",
+            "--concept-name",
+            type=str,
+            default=None,
+            help="concept name for sim to connect to",
+        )
+    
     parser.add_argument(
-        "-a",
-        "--action",
-        type=str,
-        default="Train",
-        help="action value can be Train or Assess",
-    )
-
+            "-a",
+            "--action",
+            type=str,
+            default='Train',
+            help="action value can be Train or Assess",
+        )
+    
     parser.add_argument(
-        "--interval",
-        type=int,
-        default=None,
-        help="interval to periodically run reconnect in minutes",
-    )
+            "--interval",
+            type=int,
+            default=None,
+            help="interval to periodically run reconnect in minutes",
+        )
 
     args = parser.parse_args()
-    if (
-        args.simulator_name is None
-        or args.brain_name is None
-        or args.brain_version is None
-        or args.concept_name is None
-    ):
-        parser.error(
-            "reconnect requires --simulator-name, --brain-name, --brain-version and --concept-name"
-        )
+    if args.simulator_name is None or args.brain_name is None or args.brain_version is None or args.concept_name is None:
+        parser.error("reconnect requires --simulator-name, --brain-name, --brain-version and --concept-name")
     elif args.interval is None:
         parser.error("needs --interval in minutes")
 
+    to_reverse = False
+
     while True:
+        # Toggle order of bonsai simulator unmanaged list if during deployment after retry attempts exceeded
+        to_reverse ^= False
+
+        # Run connect sim for X retry attempts, filtering for session ids and setting purpose
         connect_sim(
             simulator_name=args.simulator_name,
             brain_name=args.brain_name,
             brain_version=args.brain_version,
             concept_name=args.concept_name,
             action=args.action,
+            to_reverse=to_reverse,
         )
-        print(
-            "{}: reconnect will execute in {} min".format(
-                datetime.datetime.now(), args.interval
-            )
-        )
-        time.sleep(args.interval * 60)
+        print('{}: reconnect will execute in {} min'.format(datetime.datetime.now(),args.interval))
+        time.sleep(args.interval*60)

--- a/reconnect.py
+++ b/reconnect.py
@@ -10,6 +10,16 @@ __version__ = "0.0.5"
 import subprocess, argparse, datetime, time
 import os
 import json
+import logging
+import logging.handlers
+from rich.logging import RichHandler
+
+FORMAT = "%(message)s"
+logging.basicConfig(
+    level="INFO", format=FORMAT, datefmt="[%X]", handlers=[RichHandler(markup=True)]
+)
+
+logger = logging.getLogger("batch_containers")
 
 def parse_sim_status(to_reverse=False):
     """ Function to parse bonsai simulator unmanaged list
@@ -49,7 +59,9 @@ def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concep
             try:
                 unset_sims = parse_sim_status(to_reverse)
             except:
-                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
+                logger.warning(
+                    f'ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.'.format(retry_count)
+                )
                 continue
             for sessid in unset_sims:
                 if sessid not in blocked_list:
@@ -127,7 +139,7 @@ if __name__ == "__main__":
     parser.add_argument(
             "--interval",
             type=int,
-            default=None,
+            default=15,
             help="interval to periodically run reconnect in minutes",
         )
 

--- a/reconnect.py
+++ b/reconnect.py
@@ -5,7 +5,7 @@ python reconnect.py --simulator-name HouseEnergy --brain-name 20201116_he --brai
 """
 
 __author__ = "Brice Chung"
-__version__ = "0.0.3"
+__version__ = "0.0.5"
 
 import subprocess, argparse, datetime, time
 import os
@@ -49,8 +49,7 @@ def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concep
             try:
                 unset_sims = parse_sim_status(to_reverse)
             except:
-                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
-                time.sleep(retry_wait)
+                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
                 continue
             for sessid in unset_sims:
                 if sessid not in blocked_list:
@@ -67,13 +66,19 @@ def connect_sim(simulator_name: str, brain_name: str, brain_version: str, concep
             print('{}: command timeout, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
             time.sleep(retry_wait)
         except subprocess.SubprocessError:
-            print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-            print("We may be going through a deployment and session id: {} has become invalidated, ignoring...".format(sessid))
-            blocked_list.append(sessid)
-            print('blocked list: {}'.format(blocked_list))
-            print('{}: command error, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
-            print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-            time.sleep(retry_wait)
+            try: 
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                print("We may be going through a deployment and session id: {} has become invalidated, ignoring...".format(sessid))
+                blocked_list.append(sessid)
+                print('blocked list: {}'.format(blocked_list))
+                print('{}: command error, will retry in {} min, retry attempt {} out of {}'.format(datetime.datetime.now(),retry_wait/60, retry_count, max_retries))
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                time.sleep(retry_wait)
+            except:
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                print('ERROR from reconnect.py: No sims are available with your criteria from bonsai simulator list. Retrying {}... Perhaps spin up new sims, check network issues, or increase command timeout in reconnect.py if issue persists.'.format(retry_count))
+                print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+                time.sleep(retry_wait)
         else: 
             break
         finally:


### PR DESCRIPTION
…ent. Works with bonsai-cli=1.0.5, but not 1.0.4 so upgraded environment.yml

- ignore session id's if the bsuc command doesn't work (blocked list)
- if too many ignores happen with retries, reverse the list of session id's in hopes of connecting valid session id's
- upgrading 1.0.5 for bonsai-cli