### PR TITLE
UPDATE: adds ability for run_tasks to take a list of tasks

### DIFF
--- a/test_run_tasks.py
+++ b/test_run_tasks.py
@@ -1,0 +1,33 @@
+from batch_containers import run_tasks
+from batch_creation import user_config
+
+# Some job parameters
+POOL_NAME = "distinct-tasks-pool"
+JOB_NAME = "distinct-tasks-job"
+
+# Define the arguments your task needs
+args1 = ["output_dir"] * 3
+args2 = ["scenario1", "scenario2", "scenario3"]
+
+# Map them together as needed to make a single list of tasks
+tasks_list = list(
+    map(
+        lambda x, y: f"python main.py --log-iterations --log-path {x} --sim-name {y}",
+        args1,
+        args2,
+    )
+)
+
+# Run the tasks
+run_tasks(
+    config_file=user_config,
+    pool_name=POOL_NAME,
+    job_name=JOB_NAME,
+    task_to_run=tasks_list,
+    num_tasks=len(tasks_list),
+    low_pri_nodes=3,
+    dedicated_nodes=0,
+    vm_sku="Standard_a2_v2",
+    log_iterations=True,
+    wait_time=2,
+)


### PR DESCRIPTION
PR song: https://www.youtube.com/watch?v=yz1kvk9qeWI&ab_channel=1980tunes

## What this does?

- Ability for `batch_containers.run_tasks` to take as an argument a list of tasks instead of a singular task
- Example usage in `test_run_tasks.py`